### PR TITLE
Refactor section mappings in documentation updater

### DIFF
--- a/scripts/auto_update_docs.py
+++ b/scripts/auto_update_docs.py
@@ -273,9 +273,16 @@ def update_documentation(doc_updates: Dict) -> Dict[str, str]:
         # Find and update section
         if section:
             # Define common section name mappings for README files
+            # Map canonical section name to possible variations (without markdown prefixes)
             section_mappings = {
-                "Core Features": ["Core Features", "Features", "### Core Features", "### Features"],
-                "核心功能": ["核心功能", "功能列表", "### 核心功能", "### 功能列表"],
+                "Core Features": [
+                    "Core Features", 
+                    "Features"
+                ],
+                "核心功能": [
+                    "核心功能", 
+                    "功能列表"
+                ],
             }
             
             # Get possible section names


### PR DESCRIPTION
## 🚀 Change Type
- [ ] ✨ New Feature
- [ ] 🐞 Bug Fix
- [x] 🔧 Refactor/Maintenance
- [ ] 📚 Documentation

## 📝 Description of Changes
Refactored the section mappings in the auto_update_docs.py script by removing markdown prefixes (###) from the section name variations. This change simplifies the section mapping logic and makes it more maintainable by separating the markdown formatting concerns from the section name matching logic. The mappings now only contain the plain text variations of section names, which will be handled separately for markdown formatting during the documentation update process.

## 🧪 Testing Verification
- [ ] Verified in local environment (Local GNS3/Nornir Test)
- [ ] Run pytest and passed
- [ ] mypy and ruff checks passed

## 🔗 Related Issues
Fixes #